### PR TITLE
⚡️ Add --no-dev and -n  flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ ENV PATH="/root/.poetry/bin:${PATH}"
 COPY . /usr/src/app
 
 RUN poetry config virtualenvs.create false
-RUN poetry install --no-root
+RUN poetry install --no-root --no-dev
 
 CMD ["python", "/usr/src/app/contributor_list/main.py"]


### PR DESCRIPTION
The `--no-dev` flag skips over the dev dependencies and the `-n` flags sets poetry in "no user interactions" mode