### PR TITLE
Custom markdown header level

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jobs:
           # This enables showing contribution numbers on the README.
           # ⚠️ THIS WILL PUSH TO THE REPO AFTER EVERY COMMIT ⚠️
           show_numbers: true # Default: false
-          # Markdown heading level
+          # Markdown heading level for the contributors section
           header_level: 3 # Default: 2
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ jobs:
           # This enables showing contribution numbers on the README.
           # ⚠️ THIS WILL PUSH TO THE REPO AFTER EVERY COMMIT ⚠️
           show_numbers: true # Default: false
+          # Markdown heading level
+          header_level: 3 # Default: 2
 ```
 
 ## 🐛 Known Issues

--- a/action.yml
+++ b/action.yml
@@ -20,3 +20,7 @@ inputs:
     required: false
     default: false
     description: Whether or not to display the number of contributions
+  header_level:
+    required: false
+    default: 2
+    description: Markdown heading level for the contributors section

--- a/contributor_list/default_template.md
+++ b/contributor_list/default_template.md
@@ -1,4 +1,4 @@
-## 👥 Contributors
+{{ header_level }} 👥 Contributors
 
 {% for contributor in contributors %}
 - **[@{{ contributor.login }}]({{ contributor.html_url }})**{% if contributor.contributions %} ({{ contributor.contributions }} contribution{{ "s" if contributor.contributions != 1 }}){% endif %}

--- a/contributor_list/util.py
+++ b/contributor_list/util.py
@@ -18,18 +18,10 @@ def getTemplate(contributors: List[dict]) -> str:
     with open(file_path) as template_file:
         template = Template(template_file.read())
 
-    header_level = "##"
-    header_level_var = os.getenv("INPUT_HEADER_LEVEL")
-    if header_level_var is not None:
-        try:
-            level_count = int(header_level_var)
-            level = ""
-            for i in range(level_count):
-                level += "#"
-        except ValueError:
-            print(
-                f"Failed to convert {header_level_var} to int. Falling back on {level}."
-            )
+    level_count = int(os.getenv("INPUT_HEADER_LEVEL"))
+    header_level = ""
+    for i in range(level_count):
+        header_level += "#"
 
     return template.render({"contributors": contributors, "header_level": header_level})
 

--- a/contributor_list/util.py
+++ b/contributor_list/util.py
@@ -18,7 +18,20 @@ def getTemplate(contributors: List[dict]) -> str:
     with open(file_path) as template_file:
         template = Template(template_file.read())
 
-    return template.render({"contributors": contributors})
+    header_level = "##"
+    header_level_var = os.getenv("INPUT_HEADER_LEVEL")
+    if header_level_var is not None:
+        try:
+            level_count = int(header_level_var)
+            level = ""
+            for i in range(level_count):
+                level += "#"
+        except ValueError:
+            print(
+                f"Failed to convert {header_level_var} to int. Falling back on {level}."
+            )
+
+    return template.render({"contributors": contributors, "header_level": header_level})
 
 
 def writeToReadme(rendered: str) -> None:


### PR DESCRIPTION
Heyyyyy Caleb! This PR adds a config option called `header_level` that allows the user to define a custom markdown header level for the contributors section without having to write a custom template.